### PR TITLE
fix: let late joiners get the transcription state

### DIFF
--- a/contexts/TranscriptionProvider.js
+++ b/contexts/TranscriptionProvider.js
@@ -24,6 +24,8 @@ export const TranscriptionProvider = ({ children }) => {
 
   const handleNewMessage = useCallback(e => {
     if (e.fromId === 'transcription' && e.data?.is_final) {
+      // to let late joiners that the transcription is active.
+      setIsTranscribing(true);
       setTranscriptionHistory(oldState => [
         ...oldState,
         `${e.data.user_name}: ${e.data.text}`,


### PR DESCRIPTION
This PR is to fix the transcription state of the users who joined in late because the transcription-started event only occurs when the event starts and if the participant joins after the event, he won't be able to know that the transcription is active and we won't be showing him the transcription.